### PR TITLE
Context name

### DIFF
--- a/Samples/CSharp/snmpgetnext/Program.cs
+++ b/Samples/CSharp/snmpgetnext/Program.cs
@@ -30,6 +30,7 @@ namespace SnmpGetNext
             int retry = 0;
             Levels level = Levels.Reportable;
             string user = string.Empty;
+            string contextName = string.Empty;
             string authentication = string.Empty;
             string authPhrase = string.Empty;
             string privacy = string.Empty;
@@ -62,6 +63,7 @@ namespace SnmpGetNext
                 .Add("x:", "Privacy method", delegate(string v) { privacy = v; })
                 .Add("X:", "Privacy passphrase", delegate(string v) { privPhrase = v; })
                 .Add("u:", "Security name", delegate(string v) { user = v; })
+                .Add("n:", "Context name", delegate(string v) { contextName = v; })
                 .Add("h|?|help", "Print this help information.", delegate(string v) { showHelp = v != null; })
                 .Add("V", "Display version number of this application.", delegate (string v) { showVersion = v != null; })
                 .Add("d", "Display message dump", delegate(string v) { dump = true; })
@@ -194,7 +196,10 @@ namespace SnmpGetNext
                 Discovery discovery = Messenger.GetNextDiscovery(SnmpType.GetNextRequestPdu);
                 ReportMessage report = discovery.GetResponse(timeout, receiver);
 
-                GetNextRequestMessage request = new GetNextRequestMessage(VersionCode.V3, Messenger.NextMessageId, Messenger.NextRequestId, new OctetString(user), vList, priv, Messenger.MaxMessageSize, report);
+                GetNextRequestMessage request = string.IsNullOrEmpty(contextName) ?
+                    new GetNextRequestMessage(VersionCode.V3, Messenger.NextMessageId, Messenger.NextRequestId, new OctetString(user), vList, priv, Messenger.MaxMessageSize, report) :
+                    new GetNextRequestMessage(VersionCode.V3, Messenger.NextMessageId, Messenger.NextRequestId, new OctetString(user), new OctetString(contextName), vList, priv, Messenger.MaxMessageSize, report);
+
                 ISnmpMessage reply = request.GetResponse(timeout, receiver);
                 if (dump)
                 {
@@ -221,7 +226,10 @@ namespace SnmpGetNext
                     }
 
                     // according to RFC 3414, send a second request to sync time.
-                    request = new GetNextRequestMessage(VersionCode.V3, Messenger.NextMessageId, Messenger.NextRequestId, new OctetString(user), vList, priv, Messenger.MaxMessageSize, reply);
+                    request = string.IsNullOrEmpty(contextName) ?
+                        new GetNextRequestMessage(VersionCode.V3, Messenger.NextMessageId, Messenger.NextRequestId, new OctetString(user), vList, priv, Messenger.MaxMessageSize, reply) :
+                        new GetNextRequestMessage(VersionCode.V3, Messenger.NextMessageId, Messenger.NextRequestId, new OctetString(user), new OctetString(contextName), vList, priv, Messenger.MaxMessageSize, reply);
+
                     reply = request.GetResponse(timeout, receiver);
                 }
                 else if (reply.Pdu().ErrorStatus.ToInt32() != 0) // != ErrorCode.NoError

--- a/Samples/CSharp/snmpset/Program.cs
+++ b/Samples/CSharp/snmpset/Program.cs
@@ -30,6 +30,7 @@ namespace SnmpSet
             int retry = 0;
             Levels level = Levels.Reportable;
             string user = string.Empty;
+            string contextName = string.Empty;
             string authentication = string.Empty;
             string authPhrase = string.Empty;
             string privacy = string.Empty;
@@ -62,6 +63,7 @@ namespace SnmpSet
                 .Add("x:", "Privacy method", delegate(string v) { privacy = v; })
                 .Add("X:", "Privacy passphrase", delegate(string v) { privPhrase = v; })
                 .Add("u:", "Security name", delegate(string v) { user = v; })
+                .Add("n:", "Context name", delegate(string v) { contextName = v; })
                 .Add("h|?|help", "Print this help information.", delegate(string v) { showHelp = v != null; })
                 .Add("V", "Display version number of this application.", delegate(string v) { showVersion = v != null; })
                 .Add("d", "Display message dump", delegate(string v) { dump = true; })
@@ -225,7 +227,10 @@ namespace SnmpSet
                 Discovery discovery = Messenger.GetNextDiscovery(SnmpType.SetRequestPdu);
                 ReportMessage report = discovery.GetResponse(timeout, receiver);
 
-                SetRequestMessage request = new SetRequestMessage(VersionCode.V3, Messenger.NextMessageId, Messenger.NextRequestId, new OctetString(user), vList, priv, Messenger.MaxMessageSize, report);
+                SetRequestMessage request = string.IsNullOrEmpty(contextName) ?
+                    new SetRequestMessage(VersionCode.V3, Messenger.NextMessageId, Messenger.NextRequestId, new OctetString(user), vList, priv, Messenger.MaxMessageSize, report) :
+                    new SetRequestMessage(VersionCode.V3, Messenger.NextMessageId, Messenger.NextRequestId, new OctetString(user), new OctetString(contextName), vList, priv, Messenger.MaxMessageSize, report);
+
                 ISnmpMessage reply = request.GetResponse(timeout, receiver);
                 if (dump)
                 {
@@ -252,7 +257,10 @@ namespace SnmpSet
                     }
 
                     // according to RFC 3414, send a second request to sync time.
-                    request = new SetRequestMessage(VersionCode.V3, Messenger.NextMessageId, Messenger.NextRequestId, new OctetString(user), vList, priv, Messenger.MaxMessageSize, reply);
+                    request = string.IsNullOrEmpty(contextName) ?
+                        new SetRequestMessage(VersionCode.V3, Messenger.NextMessageId, Messenger.NextRequestId, new OctetString(user), vList, priv, Messenger.MaxMessageSize, reply) :
+                        new SetRequestMessage(VersionCode.V3, Messenger.NextMessageId, Messenger.NextRequestId, new OctetString(user), new OctetString(contextName), vList, priv, Messenger.MaxMessageSize, reply);
+
                     reply = request.GetResponse(timeout, receiver);
                 }
                 else if (reply.Pdu().ErrorStatus.ToInt32() != 0) // != ErrorCode.NoError

--- a/Samples/CSharp/snmpwalk/Program.cs
+++ b/Samples/CSharp/snmpwalk/Program.cs
@@ -32,6 +32,7 @@ namespace SnmpWalk
             int maxRepetitions = 10;
             Levels level = Levels.Reportable;
             string user = string.Empty;
+            string contextName = string.Empty;
             string authentication = string.Empty;
             string authPhrase = string.Empty;
             string privacy = string.Empty;
@@ -65,6 +66,7 @@ namespace SnmpWalk
                 .Add("x:", "Privacy method", delegate(string v) { privacy = v; })
                 .Add("X:", "Privacy passphrase", delegate(string v) { privPhrase = v; })
                 .Add("u:", "Security name", delegate(string v) { user = v; })
+                .Add("n:", "Context name", delegate(string v) { contextName = v; })
                 .Add("h|?|help", "Print this help information.", delegate(string v) { showHelp = v != null; })
                 .Add("V", "Display version number of this application.", delegate(string v) { showVersion = v != null; })
                 .Add("d", "Display message dump", delegate(string v) { dump = true; })
@@ -193,7 +195,11 @@ namespace SnmpWalk
 
                     Discovery discovery = Messenger.GetNextDiscovery(SnmpType.GetBulkRequestPdu);
                     ReportMessage report = discovery.GetResponse(timeout, receiver);
-                    Messenger.BulkWalk(version, receiver, new OctetString(user), test, result, timeout, maxRepetitions, mode, priv, report);
+
+                    if (string.IsNullOrEmpty(contextName))
+                        Messenger.BulkWalk(version, receiver, new OctetString(user), test, result, timeout, maxRepetitions, mode, priv, report);
+                    else
+                        Messenger.BulkWalk(version, receiver, new OctetString(user), new OctetString(contextName), test, result, timeout, maxRepetitions, mode, priv, report);
                 }
 
                 foreach (Variable variable in result)

--- a/Samples/VB.NET/snmpwalk/Program.vb
+++ b/Samples/VB.NET/snmpwalk/Program.vb
@@ -25,6 +25,7 @@ Module Program
         Dim maxRepetitions As Integer = 10
         Dim level As Levels = Levels.Reportable
         Dim user As String = String.Empty
+        Dim contextName As String = String.Empty
         Dim authentication As String = String.Empty
         Dim authPhrase As String = String.Empty
         Dim privacy As String = String.Empty
@@ -61,6 +62,9 @@ Module Program
                                                                              End Sub) _
                                             .Add("u:", "Security name", Sub(v As String)
                                                                             user = v
+                                                                        End Sub) _
+                                            .Add("n:", "Security name", Sub(v As String)
+                                                                            contextName = v
                                                                         End Sub) _
                                             .Add("h|?|help", "Print this help information.", Sub(v As String)
                                                                                                  showHelp__1 = v IsNot Nothing
@@ -182,8 +186,14 @@ Module Program
 
                 Dim report As ReportMessage = Messenger.GetNextDiscovery(SnmpType.GetBulkRequestPdu).GetResponse(timeout, receiver)
 
-                Messenger.BulkWalk(version, receiver, New OctetString(user), test, result, timeout, _
-                 maxRepetitions, mode, priv, report)
+                If String.IsNullOrEmpty(contextName) Then
+                    Messenger.BulkWalk(version, receiver, New OctetString(user), test, result, timeout, _
+                     maxRepetitions, mode, priv, report)
+                Else
+                    Messenger.BulkWalk(version, receiver, New OctetString(user), New OctetString(contextName), test, result, timeout, _
+                     maxRepetitions, mode, priv, report)
+                End If
+
             End If
             For Each variable As Variable In result
                 Console.WriteLine(variable)

--- a/SharpSnmpLib/Messaging/GetNextRequestMessage.cs
+++ b/SharpSnmpLib/Messaging/GetNextRequestMessage.cs
@@ -154,6 +154,74 @@ namespace Lextm.SharpSnmpLib.Messaging
             _bytes = this.PackMessage(null).ToBytes();
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GetNextRequestMessage"/> class.
+        /// </summary>
+        /// <param name="version">The version.</param>
+        /// <param name="messageId">The message id.</param>
+        /// <param name="requestId">The request id.</param>
+        /// <param name="userName">Name of the user.</param>
+        /// <param name="contextName">Name of the user.</param>
+        /// <param name="variables">The variables.</param>
+        /// <param name="privacy">The privacy provider.</param>
+        /// <param name="maxMessageSize">Size of the max message.</param>
+        /// <param name="report">The report.</param>
+        public GetNextRequestMessage(VersionCode version, int messageId, int requestId, OctetString userName, OctetString contextName, IList<Variable> variables, IPrivacyProvider privacy, int maxMessageSize, ISnmpMessage report)
+        {
+            if (variables == null)
+            {
+                throw new ArgumentNullException("variables");
+            }
+
+            if (userName == null)
+            {
+                throw new ArgumentNullException("userName");
+            }
+
+            if (contextName == null)
+            {
+                throw new ArgumentNullException("contextName");
+            }
+
+            if (version != VersionCode.V3)
+            {
+                throw new ArgumentException("only v3 is supported", "version");
+            }
+
+            if (report == null)
+            {
+                throw new ArgumentNullException("report");
+            }
+
+            if (privacy == null)
+            {
+                throw new ArgumentNullException("privacy");
+            }
+
+            Version = version;
+            Privacy = privacy;
+
+            Header = new Header(new Integer32(messageId), new Integer32(maxMessageSize), privacy.ToSecurityLevel() | Levels.Reportable);
+            var parameters = report.Parameters;
+            var authenticationProvider = Privacy.AuthenticationProvider;
+            Parameters = new SecurityParameters(
+                parameters.EngineId,
+                parameters.EngineBoots,
+                parameters.EngineTime,
+                userName,
+                authenticationProvider.CleanDigest,
+                Privacy.Salt);
+            var pdu = new GetNextRequestPdu(
+                requestId,
+                variables);
+            var scope = report.Scope;
+            var contextEngineId = scope.ContextEngineId == OctetString.Empty ? parameters.EngineId : scope.ContextEngineId;
+            Scope = new Scope(contextEngineId, contextName, pdu);
+
+            authenticationProvider.ComputeHash(Version, Header, Parameters, Scope, Privacy);
+            _bytes = this.PackMessage(null).ToBytes();
+        }
+
         internal GetNextRequestMessage(VersionCode version, Header header, SecurityParameters parameters, Scope scope, IPrivacyProvider privacy, byte[] length)
         {
             if (scope == null)

--- a/SharpSnmpLib/Messaging/Messenger.cs
+++ b/SharpSnmpLib/Messaging/Messenger.cs
@@ -261,7 +261,66 @@ namespace Lextm.SharpSnmpLib.Messaging
             IList<Variable> next;
             var result = 0;
             var message = report;
-            while (BulkHasNext(version, endpoint, community, seed, timeout, maxRepetitions, out next, privacy, ref message))
+            while (BulkHasNext(version, endpoint, community, null, seed, timeout, maxRepetitions, out next, privacy, ref message))
+            {
+                var subTreeMask = string.Format(CultureInfo.InvariantCulture, "{0}.", table);
+                var rowMask = string.Format(CultureInfo.InvariantCulture, "{0}.1.1.", table);
+                foreach (var v in next)
+                {
+                    var id = v.Id.ToString();
+                    if (v.Data.TypeCode == SnmpType.EndOfMibView)
+                    {
+                        goto end;
+                    }
+
+                    if (mode == WalkMode.WithinSubtree && !id.StartsWith(subTreeMask, StringComparison.Ordinal))
+                    {
+                        // not in sub tree
+                        goto end;
+                    }
+
+                    list.Add(v);
+                    if (id.StartsWith(rowMask, StringComparison.Ordinal))
+                    {
+                        result++;
+                    }
+                }
+
+                seed = next[next.Count - 1];
+            }
+
+        end:
+            return result;
+        }
+
+        /// <summary>
+        /// Walks.
+        /// </summary>
+        /// <param name="version">Protocol version.</param>
+        /// <param name="endpoint">Endpoint.</param>
+        /// <param name="community">Community name.</param>
+        /// <param name="contextName">Context name.</param>
+        /// <param name="table">OID.</param>
+        /// <param name="list">A list to hold the results.</param>
+        /// <param name="timeout">The time-out value, in milliseconds. The default value is 0, which indicates an infinite time-out period. Specifying -1 also indicates an infinite time-out period.</param>
+        /// <param name="maxRepetitions">The max repetitions.</param>
+        /// <param name="mode">Walk mode.</param>
+        /// <param name="privacy">The privacy provider.</param>
+        /// <param name="report">The report.</param>
+        /// <returns></returns>
+        public static int BulkWalk(VersionCode version, IPEndPoint endpoint, OctetString community, OctetString contextName, ObjectIdentifier table, IList<Variable> list, int timeout, int maxRepetitions, WalkMode mode, IPrivacyProvider privacy, ISnmpMessage report)
+        {
+            if (list == null)
+            {
+                throw new ArgumentNullException("list");
+            }
+
+            var tableV = new Variable(table);
+            var seed = tableV;
+            IList<Variable> next;
+            var result = 0;
+            var message = report;
+            while (BulkHasNext(version, endpoint, community, contextName, seed, timeout, maxRepetitions, out next, privacy, ref message))
             {
                 var subTreeMask = string.Format(CultureInfo.InvariantCulture, "{0}.", table);
                 var rowMask = string.Format(CultureInfo.InvariantCulture, "{0}.1.1.", table);
@@ -602,6 +661,7 @@ namespace Lextm.SharpSnmpLib.Messaging
         /// <param name="version">The version.</param>
         /// <param name="receiver">The receiver.</param>
         /// <param name="community">The community.</param>
+        /// <param name="contextName">The context name.</param>
         /// <param name="seed">The seed.</param>
         /// <param name="timeout">The time-out value, in milliseconds. The default value is 0, which indicates an infinite time-out period. Specifying -1 also indicates an infinite time-out period.</param>
         /// <param name="maxRepetitions">The max repetitions.</param>
@@ -612,7 +672,7 @@ namespace Lextm.SharpSnmpLib.Messaging
         /// <c>true</c> if the specified seed has next item; otherwise, <c>false</c>.
         /// </returns>
         [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "5#")]
-        private static bool BulkHasNext(VersionCode version, IPEndPoint receiver, OctetString community, Variable seed, int timeout, int maxRepetitions, out IList<Variable> next, IPrivacyProvider privacy, ref ISnmpMessage report)
+        private static bool BulkHasNext(VersionCode version, IPEndPoint receiver, OctetString community, OctetString contextName, Variable seed, int timeout, int maxRepetitions, out IList<Variable> next, IPrivacyProvider privacy, ref ISnmpMessage report)
         {
             if (version == VersionCode.V1)
             {
@@ -621,7 +681,8 @@ namespace Lextm.SharpSnmpLib.Messaging
 
             var variables = new List<Variable> { new Variable(seed.Id) };
             var request = version == VersionCode.V3
-                                                ? new GetBulkRequestMessage(
+                                                ? (contextName == null ? 
+                                                    new GetBulkRequestMessage(
                                                       version,
                                                       MessageCounter.NextId,
                                                       RequestCounter.NextId,
@@ -631,7 +692,19 @@ namespace Lextm.SharpSnmpLib.Messaging
                                                       variables,
                                                       privacy,
                                                       MaxMessageSize,
-                                                      report)
+                                                      report) :
+                                                    new GetBulkRequestMessage(
+                                                      version,
+                                                      MessageCounter.NextId,
+                                                      RequestCounter.NextId,
+                                                      community,
+                                                      contextName,
+                                                      0,
+                                                      maxRepetitions,
+                                                      variables,
+                                                      privacy,
+                                                      MaxMessageSize,
+                                                      report))
                                                 : new GetBulkRequestMessage(
                                                       RequestCounter.NextId,
                                                       version,

--- a/SharpSnmpLib/Messaging/SetRequestMessage.cs
+++ b/SharpSnmpLib/Messaging/SetRequestMessage.cs
@@ -145,6 +145,74 @@ namespace Lextm.SharpSnmpLib.Messaging
             _bytes = this.PackMessage(null).ToBytes();
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SetRequestMessage"/> class.
+        /// </summary>
+        /// <param name="version">The version.</param>
+        /// <param name="messageId">The message id.</param>
+        /// <param name="requestId">The request id.</param>
+        /// <param name="userName">Name of the user.</param>
+        /// <param name="contextName">Name of context.</param>
+        /// <param name="variables">The variables.</param>
+        /// <param name="privacy">The privacy provider.</param>
+        /// <param name="maxMessageSize">Size of the max message.</param>
+        /// <param name="report">The report.</param>
+        public SetRequestMessage(VersionCode version, int messageId, int requestId, OctetString userName, OctetString contextName, IList<Variable> variables, IPrivacyProvider privacy, int maxMessageSize, ISnmpMessage report)
+        {
+            if (variables == null)
+            {
+                throw new ArgumentNullException("variables");
+            }
+
+            if (userName == null)
+            {
+                throw new ArgumentNullException("userName");
+            }
+
+            if (contextName == null)
+            {
+                throw new ArgumentNullException("contextName");
+            }
+
+            if (version != VersionCode.V3)
+            {
+                throw new ArgumentException("only v3 is supported", "version");
+            }
+
+            if (report == null)
+            {
+                throw new ArgumentNullException("report");
+            }
+
+            if (privacy == null)
+            {
+                throw new ArgumentNullException("privacy");
+            }
+
+            Version = version;
+            Privacy = privacy;
+
+            Header = new Header(new Integer32(messageId), new Integer32(maxMessageSize), privacy.ToSecurityLevel() | Levels.Reportable);
+            var parameters = report.Parameters;
+            var authenticationProvider = Privacy.AuthenticationProvider;
+            Parameters = new SecurityParameters(
+                parameters.EngineId,
+                parameters.EngineBoots,
+                parameters.EngineTime,
+                userName,
+                authenticationProvider.CleanDigest,
+                Privacy.Salt);
+            var pdu = new SetRequestPdu(
+                requestId,
+                variables);
+            var scope = report.Scope;
+            var contextEngineId = scope.ContextEngineId == OctetString.Empty ? parameters.EngineId : scope.ContextEngineId;
+            Scope = new Scope(contextEngineId, contextName, pdu);
+
+            authenticationProvider.ComputeHash(Version, Header, Parameters, Scope, Privacy);
+            _bytes = this.PackMessage(null).ToBytes();
+        }
+
         internal SetRequestMessage(VersionCode version, Header header, SecurityParameters parameters, Scope scope, IPrivacyProvider privacy, byte[] length)
         {
             if (scope == null)


### PR DESCRIPTION
Problem: SharpSnmpLib does not allow setting the context name in V3 requests. Some agents require this. Solution: Added constructors taking context name for request messages. Added
Messenger interface for BulkWalk with context name parameter.
Added commandline parameter "n:<context name>" to sample tools. This is consistent with netsnmp command line options.
