### PR TITLE
Make NumberGenerator.NextId thread-safe

### DIFF
--- a/SharpSnmpLib/Messaging/NumberGenerator.cs
+++ b/SharpSnmpLib/Messaging/NumberGenerator.cs
@@ -40,7 +40,7 @@ namespace Lextm.SharpSnmpLib.Messaging
         }
 
         /// <summary>
-        /// Returns next ID.
+        /// Returns next ID. This method is thread-safe within this instance of NumberGenerator.
         /// </summary>
         public int NextId
         {
@@ -56,9 +56,8 @@ namespace Lextm.SharpSnmpLib.Messaging
                     {
                         _salt++;
                     }
+                    return _salt;
                 }
-
-                return _salt;
             }
         }
 


### PR DESCRIPTION
NumberGenerator is currently not thread-safe, because it returns a value outside of the lock statement.

This can be illustrated by running the code snippet:
    
    var ng = new Lextm.SharpSnmpLib.Messaging.NumberGenerator(int.MinValue, int.MaxValue);
    var list = Enumerable.Range(1, 10000).AsParallel().Select(x => ng.NextId);
    
    var dupes = list.GroupBy(x => x).Where(g => g.Count()>1).Select(x => x.Key);

    Console.WriteLine($"Duplicates: {dupes.Count()}");

Or alternatively, to show usage consistent with internal SharpSnmpLib: 

    var list = Enumerable.Range(1, 10000).AsParallel().Select(x => Lextm.SharpSnmpLib.Messaging.Messenger.NextRequestId);

In either case, if run a handful of times, you will get a non-zero count.