### PR TITLE
Correction to EngineTimeData calculations.

### DIFF
--- a/SharpSnmpLib/Pipeline/EngineGroup.cs
+++ b/SharpSnmpLib/Pipeline/EngineGroup.cs
@@ -82,9 +82,9 @@ namespace Lextm.SharpSnmpLib.Pipeline
             get
             {
                 var now = DateTime.UtcNow;
-                var ticks = (now - _start).Ticks / 10000;
-                var engineTime = (int)(ticks % int.MaxValue);
-                var engineReboots = (int)(ticks / int.MaxValue);
+                var seconds = (now - _start).Ticks / 10000000;
+                var engineTime = (int)(seconds % int.MaxValue);
+                var engineReboots = (int)(seconds / int.MaxValue);
                 return new[] { engineReboots, engineTime };
             }
         }
@@ -112,7 +112,7 @@ namespace Lextm.SharpSnmpLib.Pipeline
             }
 
             var diff = currentTimeData[1] > pastTime ? currentTimeData[1] - pastTime : currentTimeData[1] - pastTime - int.MinValue + int.MaxValue;
-            return diff >= 0 && diff <= 150000;
+            return diff >= 0 && diff <= 150;
         }
 
         /// <summary>

--- a/Tests/Pipeline/Tests/EngineGroupTestFixture.cs
+++ b/Tests/Pipeline/Tests/EngineGroupTestFixture.cs
@@ -19,11 +19,11 @@ namespace Lextm.SharpSnmpLib.Pipeline.Tests
         [Fact]
         public void TestIsInTime()
         {
-            Assert.True(EngineGroup.IsInTime(new[] { 0, 0 }, 0, -499));
-            Assert.False(EngineGroup.IsInTime(new[] { 0, 0 }, 0, -150001));
-            
-            Assert.True(EngineGroup.IsInTime(new[] { 0, int.MinValue + 1, }, 0, int.MaxValue - 1));
-            Assert.False(EngineGroup.IsInTime(new[] { 0, int.MinValue + 150002}, 0, int.MaxValue));
+            Assert.True(EngineGroup.IsInTime(new[] { 0, 0 }, 0, -4));
+            Assert.False(EngineGroup.IsInTime(new[] { 0, 0 }, 0, -151));
+
+            Assert.True(EngineGroup.IsInTime(new[] { 0, int.MinValue + 1 }, 0, int.MaxValue - 1));
+            Assert.False(EngineGroup.IsInTime(new[] { 0, int.MinValue + 152 }, 0, int.MaxValue));
         }
     }
 }


### PR DESCRIPTION
snmpEngineTime is the number of seconds since the snmpEngineBoots counter was last incremented. (https://www.ietf.org/rfc/rfc2574.txt - Section 2.2)

A single tick in DateTime.Ticks represents one hundred nanoseconds or one ten-millionth of a second.