### PR TITLE
Prevent negative request-id

### DIFF
--- a/SharpSnmpLib/Messaging/Messenger.cs
+++ b/SharpSnmpLib/Messaging/Messenger.cs
@@ -48,7 +48,7 @@ namespace Lextm.SharpSnmpLib.Messaging
         /// <summary>
         /// RFC 3416 (3.)
         /// </summary>
-        private static readonly NumberGenerator RequestCounter = new NumberGenerator(int.MinValue, int.MaxValue);
+        private static readonly NumberGenerator RequestCounter = new NumberGenerator(0, int.MaxValue);
 
         /// <summary>
         /// RFC 3412 (6.)


### PR DESCRIPTION
This fixes #30 issue for me. My old device can't handle negative request-id and the response received to such request causes the error 'truncation error for 32-bit integer coding' to be thrown by this library.