### PR TITLE
Add new project for AES encryption via BouncyCastle

### DIFF
--- a/SharpSnmpLib.BouncyCastle/BouncyCastleAES192PrivacyProvider.cs
+++ b/SharpSnmpLib.BouncyCastle/BouncyCastleAES192PrivacyProvider.cs
@@ -1,0 +1,44 @@
+﻿// Bouncy Castle AES privacy provider
+// Copyright (C) 2009-2010 Lex Li, Milan Sinadinovic
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using Lextm.SharpSnmpLib.Security;
+
+namespace Lextm.SharpSnmpLib.BouncyCastle
+{
+    /// <summary>
+    /// Privacy provider for AES 192.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "AES", Justification = "definition")]
+    public sealed class BouncyCastleAES192PrivacyProvider : BouncyCastleAESPrivacyProviderBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BouncyCastleAES192PrivacyProvider"/> class.
+        /// </summary>
+        /// <param name="phrase">The phrase.</param>
+        /// <param name="auth">The authentication provider.</param>
+        public BouncyCastleAES192PrivacyProvider(OctetString phrase, IAuthenticationProvider auth)
+            : base(24, phrase, auth)
+        { }
+
+        /// <summary>
+        /// Returns a string that represents this object.
+        /// </summary>
+        public override string ToString() => "AES 192 (BouncyCastle) privacy provider";
+    }
+}

--- a/SharpSnmpLib.BouncyCastle/BouncyCastleAES256PrivacyProvider.cs
+++ b/SharpSnmpLib.BouncyCastle/BouncyCastleAES256PrivacyProvider.cs
@@ -1,0 +1,44 @@
+﻿// Bouncy Castle AES privacy provider
+// Copyright (C) 2009-2010 Lex Li, Milan Sinadinovic
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using Lextm.SharpSnmpLib.Security;
+
+namespace Lextm.SharpSnmpLib.BouncyCastle
+{
+    /// <summary>
+    /// Privacy provider for AES 256.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "AES", Justification = "definition")]
+    public sealed class BouncyCastleAES256PrivacyProvider : BouncyCastleAESPrivacyProviderBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BouncyCastleAES256PrivacyProvider"/> class.
+        /// </summary>
+        /// <param name="phrase">The phrase.</param>
+        /// <param name="auth">The authentication provider.</param>
+        public BouncyCastleAES256PrivacyProvider(OctetString phrase, IAuthenticationProvider auth)
+            : base(32, phrase, auth)
+        { }
+
+        /// <summary>
+        /// Returns a string that represents this object.
+        /// </summary>
+        public override string ToString() => "AES 256 (BouncyCastle) privacy provider";
+    }
+}

--- a/SharpSnmpLib.BouncyCastle/BouncyCastleAESPrivacyProvider.cs
+++ b/SharpSnmpLib.BouncyCastle/BouncyCastleAESPrivacyProvider.cs
@@ -1,0 +1,44 @@
+﻿// Bouncy Castle AES privacy provider
+// Copyright (C) 2009-2010 Lex Li, Milan Sinadinovic
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using Lextm.SharpSnmpLib.Security;
+
+namespace Lextm.SharpSnmpLib.BouncyCastle
+{
+    /// <summary>
+    /// Privacy provider for AES 128.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "AES", Justification = "definition")]
+    public sealed class BouncyCastleAESPrivacyProvider : BouncyCastleAESPrivacyProviderBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BouncyCastleAESPrivacyProvider"/> class.
+        /// </summary>
+        /// <param name="phrase">The phrase.</param>
+        /// <param name="auth">The authentication provider.</param>
+        public BouncyCastleAESPrivacyProvider(OctetString phrase, IAuthenticationProvider auth)
+            : base(16, phrase, auth)
+        { }
+
+        /// <summary>
+        /// Returns a string that represents this object.
+        /// </summary>
+        public override string ToString() => "AES 128 (BouncyCastle) privacy provider";
+    }
+}

--- a/SharpSnmpLib.BouncyCastle/BouncyCastleAESPrivacyProviderBase.cs
+++ b/SharpSnmpLib.BouncyCastle/BouncyCastleAESPrivacyProviderBase.cs
@@ -1,0 +1,379 @@
+﻿// Bouncy Castle AES privacy provider
+// Copyright (C) 2009-2010 Lex Li, Milan Sinadinovic
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.IO;
+using Lextm.SharpSnmpLib.Security;
+using Org.BouncyCastle.Crypto.Engines;
+using Org.BouncyCastle.Crypto.Modes;
+using Org.BouncyCastle.Crypto.Paddings;
+using Org.BouncyCastle.Crypto.Parameters;
+
+namespace Lextm.SharpSnmpLib.BouncyCastle
+{
+    /// <summary>
+    /// Privacy provider base for AES.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "AES", Justification = "definition")]
+    public abstract class BouncyCastleAESPrivacyProviderBase : IPrivacyProvider
+    {
+        private readonly SaltGenerator _salt = new SaltGenerator();
+        private readonly OctetString _phrase;
+
+        /// <summary>
+        /// Verifies if the provider is supported.
+        /// </summary>
+        public static bool IsSupported => true;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BouncyCastleAESPrivacyProviderBase"/> class.
+        /// </summary>
+        /// <param name="keyBytes">Key bytes.</param>
+        /// <param name="phrase">The phrase.</param>
+        /// <param name="auth">The authentication provider.</param>
+        protected BouncyCastleAESPrivacyProviderBase(int keyBytes, OctetString phrase, IAuthenticationProvider auth)
+        {
+            if (keyBytes != 16 && keyBytes != 24 && keyBytes != 32)
+            {
+                throw new ArgumentOutOfRangeException(nameof(keyBytes), "Valid key sizes are 16, 24 and 32 bytes.");
+            }
+
+            if (auth == null)
+            {
+                throw new ArgumentNullException(nameof(auth));
+            }
+
+            KeyBytes = keyBytes;
+
+            // IMPORTANT: in this way privacy cannot be non-default.
+            if (auth == DefaultAuthenticationProvider.Instance)
+            {
+                throw new ArgumentException("If authentication is off, then privacy cannot be used.", nameof(auth));
+            }
+
+            _phrase = phrase ?? throw new ArgumentNullException(nameof(phrase));
+            AuthenticationProvider = auth;
+        }
+
+        /// <summary>
+        /// Corresponding <see cref="IAuthenticationProvider"/>.
+        /// </summary>
+        public IAuthenticationProvider AuthenticationProvider { get; }
+
+        /// <summary>
+        /// Engine ID.
+        /// </summary>
+        /// <remarks>This is an optional field, and only used by TRAP v2 authentication.</remarks>
+        public OctetString EngineId { get; set; }
+
+        /// <summary>
+        /// Encrypt scoped PDU
+        /// </summary>
+        /// <param name="unencryptedData">Unencrypted scoped PDU byte array</param>
+        /// <param name="key">Encryption key. Key has to be at least 32 bytes is length</param>
+        /// <param name="engineBoots">Engine boots.</param>
+        /// <param name="engineTime">Engine time.</param>
+        /// <param name="privacyParameters">Privacy parameters out buffer. This field will be filled in with information
+        /// required to decrypt the information. Output length of this field is 8 bytes and space has to be reserved
+        /// in the USM header to store this information</param>
+        /// <returns>Encrypted byte array</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when encryption key is null or length of the encryption key is too short.</exception>
+        internal byte[] Encrypt(byte[] unencryptedData, byte[] key, int engineBoots, int engineTime, byte[] privacyParameters)
+        {
+            // check the key before doing anything else
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            if (key.Length < KeyBytes)
+            {
+                throw new ArgumentOutOfRangeException(nameof(key), "Invalid key length.");
+            }
+
+            if (unencryptedData == null)
+            {
+                throw new ArgumentNullException(nameof(unencryptedData));
+            }
+
+            // Set privacy parameters to the local 64 bit salt value
+            var iv = new byte[16];
+            var bootsBytes = BitConverter.GetBytes(engineBoots);
+            iv[0] = bootsBytes[3];
+            iv[1] = bootsBytes[2];
+            iv[2] = bootsBytes[1];
+            iv[3] = bootsBytes[0];
+            var timeBytes = BitConverter.GetBytes(engineTime);
+            iv[4] = timeBytes[3];
+            iv[5] = timeBytes[2];
+            iv[6] = timeBytes[1];
+            iv[7] = timeBytes[0];
+
+            // Copy salt value to the iv array
+            Buffer.BlockCopy(privacyParameters, 0, iv, 8, PrivacyParametersLength);
+
+            // Resize the key, if necessary, to the required length
+            Array.Resize(ref key, KeyBytes);
+
+            // Encrypt using BouncyCastle
+            var blockCipher = new CfbBlockCipher(new AesEngine(), 128);
+            var paddedCipher = new PaddedBufferedBlockCipher(blockCipher, new ZeroBytePadding());
+            var cipherParameters = new ParametersWithIV(new KeyParameter(key), iv);
+            paddedCipher.Init(true, cipherParameters);
+            byte[] encryptedData = paddedCipher.DoFinal(unencryptedData);
+
+            // Trim off padding, if necessary
+            Array.Resize(ref encryptedData, unencryptedData.Length);
+
+            return encryptedData;
+        }
+
+        /// <summary>
+        /// Decrypt scoped PDU.
+        /// </summary>
+        /// <param name="encryptedData">Source data buffer</param>
+        /// <param name="engineBoots">Engine boots.</param>
+        /// <param name="engineTime">Engine time.</param>
+        /// <param name="key">Decryption key. Key length has to be 32 bytes in length or longer (bytes beyond 32 bytes are ignored).</param>
+        /// <param name="privacyParameters">Privacy parameters extracted from USM header</param>
+        /// <returns>Decrypted byte array</returns>
+        /// <exception cref="ArgumentNullException">Thrown when encrypted data is null or length == 0</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when encryption key length is less then 32 byte or if privacy parameters
+        /// argument is null or length other then 8 bytes</exception>
+        internal byte[] Decrypt(byte[] encryptedData, byte[] key, int engineBoots, int engineTime, byte[] privacyParameters)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            if (encryptedData == null)
+            {
+                throw new ArgumentNullException(nameof(encryptedData));
+            }
+
+            if (key.Length < KeyBytes)
+            {
+                throw new ArgumentOutOfRangeException(nameof(key), "Invalid key length.");
+            }
+
+            // Set privacy parameters to the local 64 bit salt value
+            var iv = new byte[16];
+            var bootsBytes = BitConverter.GetBytes(engineBoots);
+            iv[0] = bootsBytes[3];
+            iv[1] = bootsBytes[2];
+            iv[2] = bootsBytes[1];
+            iv[3] = bootsBytes[0];
+            var timeBytes = BitConverter.GetBytes(engineTime);
+            iv[4] = timeBytes[3];
+            iv[5] = timeBytes[2];
+            iv[6] = timeBytes[1];
+            iv[7] = timeBytes[0];
+
+            // Copy salt value to the iv array
+            Buffer.BlockCopy(privacyParameters, 0, iv, 8, PrivacyParametersLength);
+
+            // Resize the key, if necessary, to the required length
+            Array.Resize(ref key, KeyBytes);
+
+            // Pad encrypted data to a multiple of 16 bytes
+            byte[] encryptedDataPadded = encryptedData;
+            if (encryptedData.Length % KeyBytes != 0)
+            {
+                var div = (int)Math.Floor(encryptedData.Length / (double)16);
+                var newLength = (div + 1) * 16;
+                encryptedDataPadded = new byte[newLength];
+                Buffer.BlockCopy(encryptedData, 0, encryptedDataPadded, 0, encryptedData.Length);
+            }
+
+            // Decrypt using BouncyCastle
+            var blockCipher = new CfbBlockCipher(new AesEngine(), 128);
+            var paddedCipher = new PaddedBufferedBlockCipher(blockCipher, new ZeroBytePadding());
+            var cipherParameters = new ParametersWithIV(new KeyParameter(key), iv);
+            paddedCipher.Init(false, cipherParameters);
+            var decryptedData = paddedCipher.DoFinal(encryptedDataPadded);
+
+            // Trim off padding, if necessary
+            Array.Resize(ref decryptedData, encryptedData.Length);
+
+            return decryptedData;
+        }
+
+        /// <summary>
+        /// Returns the length of privacyParameters USM header field. For AES, field length is 8.
+        /// </summary>
+        private static int PrivacyParametersLength => 8;
+
+        /// <summary>
+        /// Returns minimum encryption/decryption key length. For DES, returned value is 16.
+        /// 
+        /// DES protocol itself requires an 8 byte key. Additional 8 bytes are used for generating the
+        /// encryption IV. For encryption itself, first 8 bytes of the key are used.
+        /// </summary>
+        private int MinimumKeyLength => KeyBytes;
+
+        /// <summary>
+        /// Return maximum encryption/decryption key length. For DES, returned value is 16
+        /// 
+        /// DES protocol itself requires an 8 byte key. Additional 8 bytes are used for generating the
+        /// encryption IV. For encryption itself, first 8 bytes of the key are used.
+        /// </summary>
+        public int MaximumKeyLength => KeyBytes;
+
+        #region IPrivacyProvider Members
+
+        /// <summary>
+        /// Decrypts the specified data.
+        /// </summary>
+        /// <param name="data">The data.</param>
+        /// <param name="parameters">The parameters.</param>
+        /// <returns></returns>
+        public ISnmpData Decrypt(ISnmpData data, SecurityParameters parameters)
+        {
+            if (parameters == null)
+            {
+                throw new ArgumentNullException(nameof(parameters));
+            }
+
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data));
+            }
+
+            var code = data.TypeCode;
+            if (code != SnmpType.OctetString)
+            {
+                throw new ArgumentException($"Cannot decrypt the scope data: {code}.", nameof(data));
+            }
+
+            var octets = (OctetString)data;
+            var bytes = octets.GetRaw();
+            var pkey = PasswordToKey(_phrase.GetRaw(), parameters.EngineId.GetRaw());
+
+            // decode encrypted packet
+            var decrypted = Decrypt(bytes, pkey, parameters.EngineBoots.ToInt32(), parameters.EngineTime.ToInt32(), parameters.PrivacyParameters.GetRaw());
+            return DataFactory.CreateSnmpData(decrypted);
+        }
+
+        /// <summary>
+        /// Encrypts the specified scope.
+        /// </summary>
+        /// <param name="data">The scope data.</param>
+        /// <param name="parameters">The parameters.</param>
+        /// <returns></returns>
+        public ISnmpData Encrypt(ISnmpData data, SecurityParameters parameters)
+        {
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data));
+            }
+
+            if (parameters == null)
+            {
+                throw new ArgumentNullException(nameof(parameters));
+            }
+
+            if (data.TypeCode != SnmpType.Sequence && !(data is ISnmpPdu))
+            {
+                throw new ArgumentException("Invalid data type.", nameof(data));
+            }
+
+            var pkey = PasswordToKey(_phrase.GetRaw(), parameters.EngineId.GetRaw());
+            var bytes = data.ToBytes();
+            var reminder = bytes.Length % 8;
+            var count = reminder == 0 ? 0 : 8 - reminder;
+            using (var stream = new MemoryStream())
+            {
+                stream.Write(bytes, 0, bytes.Length);
+                for (var i = 0; i < count; i++)
+                {
+                    stream.WriteByte(1);
+                }
+
+                bytes = stream.ToArray();
+            }
+
+            var encrypted = Encrypt(bytes, pkey, parameters.EngineBoots.ToInt32(), parameters.EngineTime.ToInt32(), parameters.PrivacyParameters.GetRaw());
+            return new OctetString(encrypted);
+        }
+
+        /// <summary>
+        /// Gets the salt.
+        /// </summary>
+        /// <value>The salt.</value>
+        public OctetString Salt => new OctetString(_salt.GetSaltBytes());
+
+        public int KeyBytes { get; }
+
+        public byte[] PasswordToKey(byte[] secret, byte[] engineId)
+        {
+            var pkey = AuthenticationProvider.PasswordToKey(secret, engineId);
+            if (pkey.Length < MinimumKeyLength)
+            {
+                pkey = ExtendShortKey(pkey, secret, engineId, AuthenticationProvider);
+            }
+
+            return pkey;
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Some protocols support a method to extend the encryption or decryption key when supplied key
+        /// is too short.
+        /// </summary>
+        /// <param name="shortKey">Key that needs to be extended</param>
+        /// <param name="password">Privacy password as configured on the SNMP agent.</param>
+        /// <param name="engineID">Authoritative engine id. Value is retrieved as part of SNMP v3 discovery procedure</param>
+        /// <param name="authProtocol">Authentication protocol class instance cast as <see cref="IAuthenticationDigest"/></param>
+        /// <returns>Extended key value</returns>
+        public byte[] ExtendShortKey(byte[] shortKey, byte[] password, byte[] engineID, IAuthenticationProvider authProtocol)
+        {
+            byte[] extKey = new byte[MinimumKeyLength];
+            byte[] lastKeyBuf = new byte[shortKey.Length];
+            Array.Copy(shortKey, lastKeyBuf, shortKey.Length);
+            int keyLen = shortKey.Length > MinimumKeyLength ? MinimumKeyLength : shortKey.Length;
+            Array.Copy(shortKey, extKey, keyLen);
+            while (keyLen < MinimumKeyLength)
+            {
+                byte[] tmpBuf = authProtocol.PasswordToKey(lastKeyBuf, engineID);
+                if (tmpBuf == null)
+                {
+                    return null;
+                }
+
+                if (tmpBuf.Length <= (MinimumKeyLength - keyLen))
+                {
+                    Array.Copy(tmpBuf, 0, extKey, keyLen, tmpBuf.Length);
+                    keyLen += tmpBuf.Length;
+                }
+                else
+                {
+                    Array.Copy(tmpBuf, 0, extKey, keyLen, MinimumKeyLength - keyLen);
+                    keyLen += (MinimumKeyLength - keyLen);
+                }
+
+                lastKeyBuf = new byte[tmpBuf.Length];
+                Array.Copy(tmpBuf, lastKeyBuf, tmpBuf.Length);
+            }
+
+            return extKey;
+        }
+    }
+}

--- a/SharpSnmpLib.BouncyCastle/SharpSnmpLib.BouncyCastle.csproj
+++ b/SharpSnmpLib.BouncyCastle/SharpSnmpLib.BouncyCastle.csproj
@@ -1,0 +1,36 @@
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+  <PropertyGroup>
+    <AssemblyName>SharpSnmpLib.BouncyCastle</AssemblyName>
+    <RootNamespace>Lextm.SharpSnmpLib.BouncyCastle</RootNamespace>
+    <TargetFrameworks>netcoreapp2.0;netstandard1.3;net452</TargetFrameworks> 
+    <PackageId>Lextm.SharpSnmpLib.BouncyCastle</PackageId>
+    <Title>#SNMP Library, Bouncy Castle encryption providers</Title>
+    <NeutralLanguage>en-US</NeutralLanguage>
+    <Authors>Malcolm Crowe,Lex Li,and other contributors.</Authors>
+    <Description>#SNMP (SharpSNMP) Library is an open source library for developers who target Microsoft .NET/Xamarin/Mono platforms. It's developed in C# and can be used for F#, VB.NET, Oxygene, and more.</Description>
+    <Summary>#SNMP (SharpSNMP) Library is an open source library for developers who target Microsoft .NET/Xamarin/Mono platforms. It's developed in C# and can be used for F#, VB.NET, Oxygene, and more. It supports .NET Framework 4.5.2 and above, as well as .NET Standard 1.3 and above.</Summary>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <PackageLicenseUrl>http://opensource.org/licenses/MIT</PackageLicenseUrl>
+    <PackageProjectUrl>https://docs.sharpsnmp.com/</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/lextm/sharpsnmplib.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageReleaseNotes>https://github.com/lextm/sharpsnmplib/releases</PackageReleaseNotes>
+    <Copyright>All rights reserved. (c) 2008-2017 Malcolm Crowe, Lex Li, and other contributors.</Copyright>
+    <PackageTags>smi snmp mib</PackageTags>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\SharpSnmpLib\sharpsnmplib.snk</AssemblyOriginatorKeyFile>
+    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">True</PublicSign>
+    <AssemblyOriginatorKeyMode>File</AssemblyOriginatorKeyMode>
+    <AssemblyVersion>10.0.9.0</AssemblyVersion>
+    <FileVersion>10.0.9.0</FileVersion>
+    <Version>10.0.9</Version>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net452' ">win</RuntimeIdentifier>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Portable.BouncyCastle" Version="1.8.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SharpSnmpLib\SharpSnmpLib.csproj" />
+  </ItemGroup>
+</Project>

--- a/SharpSnmpLib.NetStandard.sln
+++ b/SharpSnmpLib.NetStandard.sln
@@ -69,6 +69,8 @@ Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "snmptrapd", "Samples\VB.NET
 EndProject
 Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "snmpwalk", "Samples\VB.NET\snmpwalk\snmpwalk.vbproj", "{BE64B0A0-33D5-4CB0-A203-8F18266AD794}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharpSnmpLib.BouncyCastle", "SharpSnmpLib.BouncyCastle\SharpSnmpLib.BouncyCastle.csproj", "{D9404B36-10AC-48B1-BC74-2D3D12892C62}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -568,6 +570,24 @@ Global
 		{BE64B0A0-33D5-4CB0-A203-8F18266AD794}.Release|x64.Build.0 = Release|Any CPU
 		{BE64B0A0-33D5-4CB0-A203-8F18266AD794}.Release|x86.ActiveCfg = Release|x86
 		{BE64B0A0-33D5-4CB0-A203-8F18266AD794}.Release|x86.Build.0 = Release|x86
+		{D9404B36-10AC-48B1-BC74-2D3D12892C62}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D9404B36-10AC-48B1-BC74-2D3D12892C62}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D9404B36-10AC-48B1-BC74-2D3D12892C62}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D9404B36-10AC-48B1-BC74-2D3D12892C62}.Debug|x64.Build.0 = Debug|Any CPU
+		{D9404B36-10AC-48B1-BC74-2D3D12892C62}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D9404B36-10AC-48B1-BC74-2D3D12892C62}.Debug|x86.Build.0 = Debug|Any CPU
+		{D9404B36-10AC-48B1-BC74-2D3D12892C62}.Perf|Any CPU.ActiveCfg = Debug|Any CPU
+		{D9404B36-10AC-48B1-BC74-2D3D12892C62}.Perf|Any CPU.Build.0 = Debug|Any CPU
+		{D9404B36-10AC-48B1-BC74-2D3D12892C62}.Perf|x64.ActiveCfg = Debug|Any CPU
+		{D9404B36-10AC-48B1-BC74-2D3D12892C62}.Perf|x64.Build.0 = Debug|Any CPU
+		{D9404B36-10AC-48B1-BC74-2D3D12892C62}.Perf|x86.ActiveCfg = Debug|Any CPU
+		{D9404B36-10AC-48B1-BC74-2D3D12892C62}.Perf|x86.Build.0 = Debug|Any CPU
+		{D9404B36-10AC-48B1-BC74-2D3D12892C62}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D9404B36-10AC-48B1-BC74-2D3D12892C62}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D9404B36-10AC-48B1-BC74-2D3D12892C62}.Release|x64.ActiveCfg = Release|Any CPU
+		{D9404B36-10AC-48B1-BC74-2D3D12892C62}.Release|x64.Build.0 = Release|Any CPU
+		{D9404B36-10AC-48B1-BC74-2D3D12892C62}.Release|x86.ActiveCfg = Release|Any CPU
+		{D9404B36-10AC-48B1-BC74-2D3D12892C62}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
AES encryption in CFB mode, as required by SNMP, is not currently supported by the built-in cryptography API in .NET Core (See https://github.com/dotnet/corefx/issues/4647). This PR adds support for a new implementation of the AES privacy provider that utilizes the Bouncy Castle project's cryptography stack. I have validated the encryption/decryption results at various data sizes to ensure the results are consistent with .NET Framework's implementation.