### PR TITLE
More specific error code in set response

### DIFF
--- a/SharpSnmpLib/Objects/SysContact.cs
+++ b/SharpSnmpLib/Objects/SysContact.cs
@@ -62,6 +62,10 @@ namespace Lextm.SharpSnmpLib.Objects
                 {
                     throw new ArgumentException("Invalid data type.", nameof(value));
                 }
+                if (((OctetString)value).ToString().Length > 255) //respect DisplayString syntax length limitation
+                {
+                    throw new ArgumentException(nameof(ErrorCode.WrongLength));
+                }
 
                 _contact = (OctetString)value;
             }

--- a/SharpSnmpLib/Pipeline/SetMessageHandler.cs
+++ b/SharpSnmpLib/Pipeline/SetMessageHandler.cs
@@ -85,9 +85,10 @@ namespace Lextm.SharpSnmpLib.Pipeline
                     {
                         status = ErrorCode.NoAccess;
                     }
-                    catch (ArgumentException)
+                    catch (ArgumentException ex)
                     {
-                        status = ErrorCode.WrongType;
+                        if (!Enum.TryParse<ErrorCode>(ex.Message, out status) || status == ErrorCode.NoError)
+                            status = ErrorCode.WrongType;
                     }
                     catch (Exception)
                     {

--- a/Tests/CSharpCore/Integration/DaemonTestFixture.cs
+++ b/Tests/CSharpCore/Integration/DaemonTestFixture.cs
@@ -21,7 +21,7 @@ namespace Lextm.SharpSnmpLib.Integration
         private const int MaxTimeout = 5 * 60 * 1000; // 5 minutes
 
 
-        private SnmpEngine CreateEngine(bool timeout = false)
+        private SnmpEngine CreateEngine(bool timeout = false, bool max255chars = false)
         {
             // TODO: this is a hack. review it later.
             var store = new ObjectStore();
@@ -39,6 +39,10 @@ namespace Lextm.SharpSnmpLib.Integration
             if (timeout)
             {
                 store.Add(new TimeoutObject());
+            }
+            if (max255chars)
+            {
+                store.Add(new Max255CharsObject());
             }
 
             var users = new UserRegistry();
@@ -111,6 +115,42 @@ namespace Lextm.SharpSnmpLib.Integration
                 set
                 {
                     throw new NotImplementedException();
+                }
+            }
+        }
+        private class Max255CharsObject : ScalarObject
+        {
+            private OctetString _data = new OctetString("");
+
+            public Max255CharsObject()
+                : base(new ObjectIdentifier("1.5.3"))
+            {
+
+            }
+
+            public override ISnmpData Data
+            {
+                get
+                {
+                    return _data;
+                }
+
+                set
+                {
+                    if (value == null)
+                    {
+                        throw new ArgumentNullException(nameof(value));
+                    }
+                    if (value.TypeCode != SnmpType.OctetString)
+                    {
+                        throw new ArgumentException("Invalid data type.", nameof(value));
+                    }
+                    if (((OctetString)value).ToString().Length > 255)
+                    {
+                        throw new ArgumentException(nameof(ErrorCode.WrongLength));
+                    }
+
+                    _data = (OctetString)value;
                 }
             }
         }
@@ -616,7 +656,7 @@ namespace Lextm.SharpSnmpLib.Integration
                             {
                                 GetRequestMessage message = new GetRequestMessage(index, VersionCode.V2,
                                     new OctetString("public"),
-                                    new List<Variable> { new Variable( new ObjectIdentifier("1.3.6.1.2.1.1.1.0")) });
+                                    new List<Variable> {new Variable(new ObjectIdentifier("1.3.6.1.2.1.1.1.0")) });
                                 // Comment below to reveal wrong sequence number issue.
                                 Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram,
                                     ProtocolType.Udp);
@@ -733,7 +773,7 @@ namespace Lextm.SharpSnmpLib.Integration
         [Fact]
         public void TestSetWrongLength()
         {
-            var engine = CreateEngine();
+            var engine = CreateEngine(max255chars: true);
             engine.Listener.ClearBindings();
             var serverEndPoint = new IPEndPoint(IPAddress.Loopback, Port.NextId);
             engine.Listener.AddBinding(serverEndPoint);
@@ -743,12 +783,20 @@ namespace Lextm.SharpSnmpLib.Integration
             {
                 Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
 
-                var syscontact_toolong = new Variable((new SysContact()).Variable.Id, new OctetString(new string('x', 256)));
+                var string_toolong = new Variable((new Max255CharsObject()).Variable.Id, new OctetString(new string('x', 256)));
                 SetRequestMessage message = new SetRequestMessage(0x4bed, VersionCode.V2, new OctetString("public"),
-                    new List<Variable> { syscontact_toolong });
+                    new List<Variable> { string_toolong });
 
                 var resp = message.GetResponse(1500, serverEndPoint, socket);
                 Assert.Equal(ErrorCode.WrongLength, resp.Pdu().ErrorStatus.ToErrorCode());
+                Assert.Equal(1, resp.Pdu().ErrorIndex.ToInt32());
+
+                var wrong_type = new Variable((new Max255CharsObject()).Variable.Id, new Integer32(666));
+                message = new SetRequestMessage(0x4bed, VersionCode.V2, new OctetString("public"),
+                    new List<Variable> { wrong_type });
+
+                resp = message.GetResponse(1500, serverEndPoint, socket);
+                Assert.Equal(ErrorCode.WrongType, resp.Pdu().ErrorStatus.ToErrorCode());
                 Assert.Equal(1, resp.Pdu().ErrorIndex.ToInt32());
             }
             finally

--- a/Tests/CSharpCore/Integration/DaemonTestFixture.cs
+++ b/Tests/CSharpCore/Integration/DaemonTestFixture.cs
@@ -743,9 +743,9 @@ namespace Lextm.SharpSnmpLib.Integration
             {
                 Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
 
-                var syscontanct_toolong = new Variable((new SysContact()).Variable.Id, new OctetString(new string('x', 256)));
+                var syscontact_toolong = new Variable((new SysContact()).Variable.Id, new OctetString(new string('x', 256)));
                 SetRequestMessage message = new SetRequestMessage(0x4bed, VersionCode.V2, new OctetString("public"),
-                    new List<Variable> { syscontanct_toolong });
+                    new List<Variable> { syscontact_toolong });
 
                 var resp = message.GetResponse(1500, serverEndPoint, socket);
                 Assert.Equal(ErrorCode.WrongLength, resp.Pdu().ErrorStatus.ToErrorCode());


### PR DESCRIPTION
In case an ArgumentException is caught while applying the data of a set request, try parse the exception's message and derive the ErrorCode for the set response from it, if possible (if not possible fallback to ErrorCode.WrongType like it was before this change).